### PR TITLE
Explicit dependency on VPC

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -109,6 +109,8 @@ module "elb_http" {
 module "ec2_instances" {
   source = "./modules/aws-instance"
 
+  depends_on = [module.vpc]
+
   instance_count     = 2
   instance_type      = "t2.micro"
   subnet_ids         = module.vpc.private_subnets[*]


### PR DESCRIPTION
Resolves an issue where the EC2 instances do not complete provisioning because the NAT gateways are not yet ready. The provisioning script (user_data) is unable to access the internet to install the httpd package.  Instead of "Hello, world!", the learner sees a blank page and the browser reports a 504 response code. This is detrimental to the learning process.

<details>
<summary>Output from `tf apply`</summary>

```
data.aws_availability_zones.available: Reading...
data.aws_availability_zones.available: Read complete after 1s [id=us-west-2]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # random_string.lb_id will be created
  + resource "random_string" "lb_id" {
      + id          = (known after apply)
      + length      = 3
      + lower       = true
      + min_lower   = 0
      + min_numeric = 0
      + min_special = 0
      + min_upper   = 0
      + number      = true
      + result      = (known after apply)
      + special     = false
      + upper       = true
    }

  # module.ec2_instances.data.aws_ami.amazon_linux will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "aws_ami" "amazon_linux" {
      + architecture          = (known after apply)
      + arn                   = (known after apply)
      + block_device_mappings = (known after apply)
      + creation_date         = (known after apply)
      + description           = (known after apply)
      + hypervisor            = (known after apply)
      + id                    = (known after apply)
      + image_id              = (known after apply)
      + image_location        = (known after apply)
      + image_owner_alias     = (known after apply)
      + image_type            = (known after apply)
      + kernel_id             = (known after apply)
      + most_recent           = true
      + name                  = (known after apply)
      + owner_id              = (known after apply)
      + owners                = [
          + "amazon",
        ]
      + platform              = (known after apply)
      + product_codes         = (known after apply)
      + public                = (known after apply)
      + ramdisk_id            = (known after apply)
      + root_device_name      = (known after apply)
      + root_device_type      = (known after apply)
      + root_snapshot_id      = (known after apply)
      + sriov_net_support     = (known after apply)
      + state                 = (known after apply)
      + state_reason          = (known after apply)
      + tags                  = (known after apply)
      + virtualization_type   = (known after apply)

      + filter {
          + name   = "name"
          + values = [
              + "amzn2-ami-hvm-*-x86_64-gp2",
            ]
        }
    }

  # module.ec2_instances.aws_instance.app[0] will be created
  + resource "aws_instance" "app" {
      + ami                          = (known after apply)
      + arn                          = (known after apply)
      + associate_public_ip_address  = (known after apply)
      + availability_zone            = (known after apply)
      + cpu_core_count               = (known after apply)
      + cpu_threads_per_core         = (known after apply)
      + get_password_data            = false
      + host_id                      = (known after apply)
      + id                           = (known after apply)
      + instance_state               = (known after apply)
      + instance_type                = "t2.micro"
      + ipv6_address_count           = (known after apply)
      + ipv6_addresses               = (known after apply)
      + key_name                     = (known after apply)
      + outpost_arn                  = (known after apply)
      + password_data                = (known after apply)
      + placement_group              = (known after apply)
      + primary_network_interface_id = (known after apply)
      + private_dns                  = (known after apply)
      + private_ip                   = (known after apply)
      + public_dns                   = (known after apply)
      + public_ip                    = (known after apply)
      + secondary_private_ips        = (known after apply)
      + security_groups              = (known after apply)
      + source_dest_check            = true
      + subnet_id                    = (known after apply)
      + tags                         = {
          + "environment" = "dev"
          + "project"     = "project-alpha"
        }
      + tenancy                      = (known after apply)
      + user_data                    = "3b21b980468438c9034158841596d57f1283de5c"
      + volume_tags                  = (known after apply)
      + vpc_security_group_ids       = (known after apply)

      + ebs_block_device {
          + delete_on_termination = (known after apply)
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + snapshot_id           = (known after apply)
          + throughput            = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = (known after apply)
          + volume_type           = (known after apply)
        }

      + enclave_options {
          + enabled = (known after apply)
        }

      + ephemeral_block_device {
          + device_name  = (known after apply)
          + no_device    = (known after apply)
          + virtual_name = (known after apply)
        }

      + metadata_options {
          + http_endpoint               = (known after apply)
          + http_put_response_hop_limit = (known after apply)
          + http_tokens                 = (known after apply)
        }

      + network_interface {
          + delete_on_termination = (known after apply)
          + device_index          = (known after apply)
          + network_interface_id  = (known after apply)
        }

      + root_block_device {
          + delete_on_termination = (known after apply)
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + throughput            = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = (known after apply)
          + volume_type           = (known after apply)
        }
    }

  # module.ec2_instances.aws_instance.app[1] will be created
  + resource "aws_instance" "app" {
      + ami                          = (known after apply)
      + arn                          = (known after apply)
      + associate_public_ip_address  = (known after apply)
      + availability_zone            = (known after apply)
      + cpu_core_count               = (known after apply)
      + cpu_threads_per_core         = (known after apply)
      + get_password_data            = false
      + host_id                      = (known after apply)
      + id                           = (known after apply)
      + instance_state               = (known after apply)
      + instance_type                = "t2.micro"
      + ipv6_address_count           = (known after apply)
      + ipv6_addresses               = (known after apply)
      + key_name                     = (known after apply)
      + outpost_arn                  = (known after apply)
      + password_data                = (known after apply)
      + placement_group              = (known after apply)
      + primary_network_interface_id = (known after apply)
      + private_dns                  = (known after apply)
      + private_ip                   = (known after apply)
      + public_dns                   = (known after apply)
      + public_ip                    = (known after apply)
      + secondary_private_ips        = (known after apply)
      + security_groups              = (known after apply)
      + source_dest_check            = true
      + subnet_id                    = (known after apply)
      + tags                         = {
          + "environment" = "dev"
          + "project"     = "project-alpha"
        }
      + tenancy                      = (known after apply)
      + user_data                    = "3b21b980468438c9034158841596d57f1283de5c"
      + volume_tags                  = (known after apply)
      + vpc_security_group_ids       = (known after apply)

      + ebs_block_device {
          + delete_on_termination = (known after apply)
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + snapshot_id           = (known after apply)
          + throughput            = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = (known after apply)
          + volume_type           = (known after apply)
        }

      + enclave_options {
          + enabled = (known after apply)
        }

      + ephemeral_block_device {
          + device_name  = (known after apply)
          + no_device    = (known after apply)
          + virtual_name = (known after apply)
        }

      + metadata_options {
          + http_endpoint               = (known after apply)
          + http_put_response_hop_limit = (known after apply)
          + http_tokens                 = (known after apply)
        }

      + network_interface {
          + delete_on_termination = (known after apply)
          + device_index          = (known after apply)
          + network_interface_id  = (known after apply)
        }

      + root_block_device {
          + delete_on_termination = (known after apply)
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + throughput            = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = (known after apply)
          + volume_type           = (known after apply)
        }
    }

  # module.vpc.aws_eip.nat[0] will be created
  + resource "aws_eip" "nat" {
      + allocation_id        = (known after apply)
      + association_id       = (known after apply)
      + carrier_ip           = (known after apply)
      + customer_owned_ip    = (known after apply)
      + domain               = (known after apply)
      + id                   = (known after apply)
      + instance             = (known after apply)
      + network_border_group = (known after apply)
      + network_interface    = (known after apply)
      + private_dns          = (known after apply)
      + private_ip           = (known after apply)
      + public_dns           = (known after apply)
      + public_ip            = (known after apply)
      + public_ipv4_pool     = (known after apply)
      + tags                 = {
          + "Name"        = "-us-west-2a"
          + "environment" = "dev"
          + "project"     = "project-alpha"
        }
      + vpc                  = true
    }

  # module.vpc.aws_eip.nat[1] will be created
  + resource "aws_eip" "nat" {
      + allocation_id        = (known after apply)
      + association_id       = (known after apply)
      + carrier_ip           = (known after apply)
      + customer_owned_ip    = (known after apply)
      + domain               = (known after apply)
      + id                   = (known after apply)
      + instance             = (known after apply)
      + network_border_group = (known after apply)
      + network_interface    = (known after apply)
      + private_dns          = (known after apply)
      + private_ip           = (known after apply)
      + public_dns           = (known after apply)
      + public_ip            = (known after apply)
      + public_ipv4_pool     = (known after apply)
      + tags                 = {
          + "Name"        = "-us-west-2b"
          + "environment" = "dev"
          + "project"     = "project-alpha"
        }
      + vpc                  = true
    }

  # module.vpc.aws_internet_gateway.this[0] will be created
  + resource "aws_internet_gateway" "this" {
      + arn      = (known after apply)
      + id       = (known after apply)
      + owner_id = (known after apply)
      + tags     = {
          + "Name"        = ""
          + "environment" = "dev"
          + "project"     = "project-alpha"
        }
      + vpc_id   = (known after apply)
    }

  # module.vpc.aws_nat_gateway.this[0] will be created
  + resource "aws_nat_gateway" "this" {
      + allocation_id        = (known after apply)
      + id                   = (known after apply)
      + network_interface_id = (known after apply)
      + private_ip           = (known after apply)
      + public_ip            = (known after apply)
      + subnet_id            = (known after apply)
      + tags                 = {
          + "Name"        = "-us-west-2a"
          + "environment" = "dev"
          + "project"     = "project-alpha"
        }
    }

  # module.vpc.aws_nat_gateway.this[1] will be created
  + resource "aws_nat_gateway" "this" {
      + allocation_id        = (known after apply)
      + id                   = (known after apply)
      + network_interface_id = (known after apply)
      + private_ip           = (known after apply)
      + public_ip            = (known after apply)
      + subnet_id            = (known after apply)
      + tags                 = {
          + "Name"        = "-us-west-2b"
          + "environment" = "dev"
          + "project"     = "project-alpha"
        }
    }

  # module.vpc.aws_route.private_nat_gateway[0] will be created
  + resource "aws_route" "private_nat_gateway" {
      + destination_cidr_block     = "0.0.0.0/0"
      + destination_prefix_list_id = (known after apply)
      + egress_only_gateway_id     = (known after apply)
      + gateway_id                 = (known after apply)
      + id                         = (known after apply)
      + instance_id                = (known after apply)
      + instance_owner_id          = (known after apply)
      + local_gateway_id           = (known after apply)
      + nat_gateway_id             = (known after apply)
      + network_interface_id       = (known after apply)
      + origin                     = (known after apply)
      + route_table_id             = (known after apply)
      + state                      = (known after apply)

      + timeouts {
          + create = "5m"
        }
    }

  # module.vpc.aws_route.private_nat_gateway[1] will be created
  + resource "aws_route" "private_nat_gateway" {
      + destination_cidr_block     = "0.0.0.0/0"
      + destination_prefix_list_id = (known after apply)
      + egress_only_gateway_id     = (known after apply)
      + gateway_id                 = (known after apply)
      + id                         = (known after apply)
      + instance_id                = (known after apply)
      + instance_owner_id          = (known after apply)
      + local_gateway_id           = (known after apply)
      + nat_gateway_id             = (known after apply)
      + network_interface_id       = (known after apply)
      + origin                     = (known after apply)
      + route_table_id             = (known after apply)
      + state                      = (known after apply)

      + timeouts {
          + create = "5m"
        }
    }

  # module.vpc.aws_route.public_internet_gateway[0] will be created
  + resource "aws_route" "public_internet_gateway" {
      + destination_cidr_block     = "0.0.0.0/0"
      + destination_prefix_list_id = (known after apply)
      + egress_only_gateway_id     = (known after apply)
      + gateway_id                 = (known after apply)
      + id                         = (known after apply)
      + instance_id                = (known after apply)
      + instance_owner_id          = (known after apply)
      + local_gateway_id           = (known after apply)
      + nat_gateway_id             = (known after apply)
      + network_interface_id       = (known after apply)
      + origin                     = (known after apply)
      + route_table_id             = (known after apply)
      + state                      = (known after apply)

      + timeouts {
          + create = "5m"
        }
    }

  # module.vpc.aws_route_table.private[0] will be created
  + resource "aws_route_table" "private" {
      + id               = (known after apply)
      + owner_id         = (known after apply)
      + propagating_vgws = (known after apply)
      + route            = (known after apply)
      + tags             = {
          + "Name"        = "-private-us-west-2a"
          + "environment" = "dev"
          + "project"     = "project-alpha"
        }
      + vpc_id           = (known after apply)
    }

  # module.vpc.aws_route_table.private[1] will be created
  + resource "aws_route_table" "private" {
      + id               = (known after apply)
      + owner_id         = (known after apply)
      + propagating_vgws = (known after apply)
      + route            = (known after apply)
      + tags             = {
          + "Name"        = "-private-us-west-2b"
          + "environment" = "dev"
          + "project"     = "project-alpha"
        }
      + vpc_id           = (known after apply)
    }

  # module.vpc.aws_route_table.public[0] will be created
  + resource "aws_route_table" "public" {
      + id               = (known after apply)
      + owner_id         = (known after apply)
      + propagating_vgws = (known after apply)
      + route            = (known after apply)
      + tags             = {
          + "Name"        = "-public"
          + "environment" = "dev"
          + "project"     = "project-alpha"
        }
      + vpc_id           = (known after apply)
    }

  # module.vpc.aws_route_table_association.private[0] will be created
  + resource "aws_route_table_association" "private" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.vpc.aws_route_table_association.private[1] will be created
  + resource "aws_route_table_association" "private" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.vpc.aws_route_table_association.public[0] will be created
  + resource "aws_route_table_association" "public" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.vpc.aws_route_table_association.public[1] will be created
  + resource "aws_route_table_association" "public" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.vpc.aws_subnet.private[0] will be created
  + resource "aws_subnet" "private" {
      + arn                             = (known after apply)
      + assign_ipv6_address_on_creation = false
      + availability_zone               = "us-west-2a"
      + availability_zone_id            = (known after apply)
      + cidr_block                      = "10.0.101.0/24"
      + id                              = (known after apply)
      + ipv6_cidr_block_association_id  = (known after apply)
      + map_public_ip_on_launch         = false
      + owner_id                        = (known after apply)
      + tags                            = {
          + "Name"        = "-private-us-west-2a"
          + "environment" = "dev"
          + "project"     = "project-alpha"
        }
      + vpc_id                          = (known after apply)
    }

  # module.vpc.aws_subnet.private[1] will be created
  + resource "aws_subnet" "private" {
      + arn                             = (known after apply)
      + assign_ipv6_address_on_creation = false
      + availability_zone               = "us-west-2b"
      + availability_zone_id            = (known after apply)
      + cidr_block                      = "10.0.102.0/24"
      + id                              = (known after apply)
      + ipv6_cidr_block_association_id  = (known after apply)
      + map_public_ip_on_launch         = false
      + owner_id                        = (known after apply)
      + tags                            = {
          + "Name"        = "-private-us-west-2b"
          + "environment" = "dev"
          + "project"     = "project-alpha"
        }
      + vpc_id                          = (known after apply)
    }

  # module.vpc.aws_subnet.public[0] will be created
  + resource "aws_subnet" "public" {
      + arn                             = (known after apply)
      + assign_ipv6_address_on_creation = false
      + availability_zone               = "us-west-2a"
      + availability_zone_id            = (known after apply)
      + cidr_block                      = "10.0.1.0/24"
      + id                              = (known after apply)
      + ipv6_cidr_block_association_id  = (known after apply)
      + map_public_ip_on_launch         = true
      + owner_id                        = (known after apply)
      + tags                            = {
          + "Name"        = "-public-us-west-2a"
          + "environment" = "dev"
          + "project"     = "project-alpha"
        }
      + vpc_id                          = (known after apply)
    }

  # module.vpc.aws_subnet.public[1] will be created
  + resource "aws_subnet" "public" {
      + arn                             = (known after apply)
      + assign_ipv6_address_on_creation = false
      + availability_zone               = "us-west-2b"
      + availability_zone_id            = (known after apply)
      + cidr_block                      = "10.0.2.0/24"
      + id                              = (known after apply)
      + ipv6_cidr_block_association_id  = (known after apply)
      + map_public_ip_on_launch         = true
      + owner_id                        = (known after apply)
      + tags                            = {
          + "Name"        = "-public-us-west-2b"
          + "environment" = "dev"
          + "project"     = "project-alpha"
        }
      + vpc_id                          = (known after apply)
    }

  # module.vpc.aws_vpc.this[0] will be created
  + resource "aws_vpc" "this" {
      + arn                              = (known after apply)
      + assign_generated_ipv6_cidr_block = false
      + cidr_block                       = "10.0.0.0/16"
      + default_network_acl_id           = (known after apply)
      + default_route_table_id           = (known after apply)
      + default_security_group_id        = (known after apply)
      + dhcp_options_id                  = (known after apply)
      + enable_classiclink               = (known after apply)
      + enable_classiclink_dns_support   = (known after apply)
      + enable_dns_hostnames             = false
      + enable_dns_support               = true
      + id                               = (known after apply)
      + instance_tenancy                 = "default"
      + ipv6_association_id              = (known after apply)
      + ipv6_cidr_block                  = (known after apply)
      + main_route_table_id              = (known after apply)
      + owner_id                         = (known after apply)
      + tags                             = {
          + "Name"        = ""
          + "environment" = "dev"
          + "project"     = "project-alpha"
        }
    }

  # module.app_security_group.module.sg.aws_security_group.this_name_prefix[0] will be created
  + resource "aws_security_group" "this_name_prefix" {
      + arn                    = (known after apply)
      + description            = "Security group for web-servers with HTTP ports open within VPC"
      + egress                 = (known after apply)
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = (known after apply)
      + name_prefix            = "web-sg-project-alpha-dev-"
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Name"        = "web-sg-project-alpha-dev"
          + "environment" = "dev"
          + "project"     = "project-alpha"
        }
      + vpc_id                 = (known after apply)
    }

  # module.app_security_group.module.sg.aws_security_group_rule.egress_rules[0] will be created
  + resource "aws_security_group_rule" "egress_rules" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "All protocols"
      + from_port                = -1
      + id                       = (known after apply)
      + ipv6_cidr_blocks         = [
          + "::/0",
        ]
      + prefix_list_ids          = []
      + protocol                 = "-1"
      + security_group_id        = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = -1
      + type                     = "egress"
    }

  # module.app_security_group.module.sg.aws_security_group_rule.ingress_rules[0] will be created
  + resource "aws_security_group_rule" "ingress_rules" {
      + cidr_blocks              = [
          + "10.0.1.0/24",
          + "10.0.2.0/24",
        ]
      + description              = "HTTP"
      + from_port                = 80
      + id                       = (known after apply)
      + ipv6_cidr_blocks         = []
      + prefix_list_ids          = []
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 80
      + type                     = "ingress"
    }

  # module.app_security_group.module.sg.aws_security_group_rule.ingress_rules[1] will be created
  + resource "aws_security_group_rule" "ingress_rules" {
      + cidr_blocks              = [
          + "10.0.1.0/24",
          + "10.0.2.0/24",
        ]
      + description              = "HTTP"
      + from_port                = 8080
      + id                       = (known after apply)
      + ipv6_cidr_blocks         = []
      + prefix_list_ids          = []
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 8080
      + type                     = "ingress"
    }

  # module.app_security_group.module.sg.aws_security_group_rule.ingress_rules[2] will be created
  + resource "aws_security_group_rule" "ingress_rules" {
      + cidr_blocks              = [
          + "10.0.1.0/24",
          + "10.0.2.0/24",
        ]
      + description              = "HTTPS"
      + from_port                = 443
      + id                       = (known after apply)
      + ipv6_cidr_blocks         = []
      + prefix_list_ids          = []
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 443
      + type                     = "ingress"
    }

  # module.app_security_group.module.sg.aws_security_group_rule.ingress_rules[3] will be created
  + resource "aws_security_group_rule" "ingress_rules" {
      + cidr_blocks              = [
          + "10.0.1.0/24",
          + "10.0.2.0/24",
        ]
      + description              = "JMX"
      + from_port                = 1099
      + id                       = (known after apply)
      + ipv6_cidr_blocks         = []
      + prefix_list_ids          = []
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 1099
      + type                     = "ingress"
    }

  # module.app_security_group.module.sg.aws_security_group_rule.ingress_with_self[0] will be created
  + resource "aws_security_group_rule" "ingress_with_self" {
      + description              = "Ingress Rule"
      + from_port                = -1
      + id                       = (known after apply)
      + prefix_list_ids          = []
      + protocol                 = "-1"
      + security_group_id        = (known after apply)
      + self                     = true
      + source_security_group_id = (known after apply)
      + to_port                  = -1
      + type                     = "ingress"
    }

  # module.elb_http.module.elb.aws_elb.this[0] will be created
  + resource "aws_elb" "this" {
      + arn                         = (known after apply)
      + availability_zones          = (known after apply)
      + connection_draining         = false
      + connection_draining_timeout = 300
      + cross_zone_load_balancing   = true
      + dns_name                    = (known after apply)
      + id                          = (known after apply)
      + idle_timeout                = 60
      + instances                   = (known after apply)
      + internal                    = false
      + name                        = (known after apply)
      + security_groups             = (known after apply)
      + source_security_group       = (known after apply)
      + source_security_group_id    = (known after apply)
      + subnets                     = (known after apply)
      + tags                        = (known after apply)
      + zone_id                     = (known after apply)

      + health_check {
          + healthy_threshold   = 3
          + interval            = 10
          + target              = "HTTP:80/index.html"
          + timeout             = 5
          + unhealthy_threshold = 10
        }

      + listener {
          + instance_port     = 80
          + instance_protocol = "HTTP"
          + lb_port           = 80
          + lb_protocol       = "HTTP"
        }
    }

  # module.elb_http.module.elb_attachment.aws_elb_attachment.this[0] will be created
  + resource "aws_elb_attachment" "this" {
      + elb      = (known after apply)
      + id       = (known after apply)
      + instance = (known after apply)
    }

  # module.elb_http.module.elb_attachment.aws_elb_attachment.this[1] will be created
  + resource "aws_elb_attachment" "this" {
      + elb      = (known after apply)
      + id       = (known after apply)
      + instance = (known after apply)
    }

  # module.lb_security_group.module.sg.aws_security_group.this_name_prefix[0] will be created
  + resource "aws_security_group" "this_name_prefix" {
      + arn                    = (known after apply)
      + description            = "Security group for load balancer with HTTP ports open within VPC"
      + egress                 = (known after apply)
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = (known after apply)
      + name_prefix            = "lb-sg-project-alpha-dev-"
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Name"        = "lb-sg-project-alpha-dev"
          + "environment" = "dev"
          + "project"     = "project-alpha"
        }
      + vpc_id                 = (known after apply)
    }

  # module.lb_security_group.module.sg.aws_security_group_rule.egress_rules[0] will be created
  + resource "aws_security_group_rule" "egress_rules" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "All protocols"
      + from_port                = -1
      + id                       = (known after apply)
      + ipv6_cidr_blocks         = [
          + "::/0",
        ]
      + prefix_list_ids          = []
      + protocol                 = "-1"
      + security_group_id        = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = -1
      + type                     = "egress"
    }

  # module.lb_security_group.module.sg.aws_security_group_rule.ingress_rules[0] will be created
  + resource "aws_security_group_rule" "ingress_rules" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "HTTP"
      + from_port                = 80
      + id                       = (known after apply)
      + ipv6_cidr_blocks         = []
      + prefix_list_ids          = []
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 80
      + type                     = "ingress"
    }

  # module.lb_security_group.module.sg.aws_security_group_rule.ingress_rules[1] will be created
  + resource "aws_security_group_rule" "ingress_rules" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "HTTP"
      + from_port                = 8080
      + id                       = (known after apply)
      + ipv6_cidr_blocks         = []
      + prefix_list_ids          = []
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 8080
      + type                     = "ingress"
    }

  # module.lb_security_group.module.sg.aws_security_group_rule.ingress_rules[2] will be created
  + resource "aws_security_group_rule" "ingress_rules" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "HTTPS"
      + from_port                = 443
      + id                       = (known after apply)
      + ipv6_cidr_blocks         = []
      + prefix_list_ids          = []
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 443
      + type                     = "ingress"
    }

  # module.lb_security_group.module.sg.aws_security_group_rule.ingress_rules[3] will be created
  + resource "aws_security_group_rule" "ingress_rules" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "JMX"
      + from_port                = 1099
      + id                       = (known after apply)
      + ipv6_cidr_blocks         = []
      + prefix_list_ids          = []
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 1099
      + type                     = "ingress"
    }

  # module.lb_security_group.module.sg.aws_security_group_rule.ingress_with_self[0] will be created
  + resource "aws_security_group_rule" "ingress_with_self" {
      + description              = "Ingress Rule"
      + from_port                = -1
      + id                       = (known after apply)
      + prefix_list_ids          = []
      + protocol                 = "-1"
      + security_group_id        = (known after apply)
      + self                     = true
      + source_security_group_id = (known after apply)
      + to_port                  = -1
      + type                     = "ingress"
    }

Plan: 40 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + public_dns_name = (known after apply)

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

random_string.lb_id: Creating...
random_string.lb_id: Creation complete after 0s [id=BfA]
module.vpc.aws_vpc.this[0]: Creating...
module.vpc.aws_eip.nat[0]: Creating...
module.vpc.aws_eip.nat[1]: Creating...
module.vpc.aws_eip.nat[1]: Creation complete after 1s [id=eipalloc-01ec0fc1558afa185]
module.vpc.aws_eip.nat[0]: Creation complete after 2s [id=eipalloc-0cc680619c06fe435]
module.vpc.aws_vpc.this[0]: Creation complete after 4s [id=vpc-0e0370083e8259a31]
module.vpc.aws_route_table.public[0]: Creating...
module.vpc.aws_route_table.private[1]: Creating...
module.vpc.aws_route_table.private[0]: Creating...
module.vpc.aws_subnet.private[0]: Creating...
module.vpc.aws_subnet.public[0]: Creating...
module.vpc.aws_internet_gateway.this[0]: Creating...
module.vpc.aws_subnet.public[1]: Creating...
module.vpc.aws_subnet.private[1]: Creating...
module.app_security_group.module.sg.aws_security_group.this_name_prefix[0]: Creating...
module.lb_security_group.module.sg.aws_security_group.this_name_prefix[0]: Creating...
module.vpc.aws_route_table.private[1]: Creation complete after 1s [id=rtb-0779b38e7c6bff2b8]
module.vpc.aws_route_table.private[0]: Creation complete after 1s [id=rtb-0796930b3c1640381]
module.vpc.aws_route_table.public[0]: Creation complete after 1s [id=rtb-0490a1cb8968830c1]
module.vpc.aws_subnet.private[0]: Creation complete after 1s [id=subnet-03313a3655e477385]
module.vpc.aws_internet_gateway.this[0]: Creation complete after 2s [id=igw-01c1d9d2444f49366]
module.vpc.aws_subnet.public[1]: Creation complete after 2s [id=subnet-0708329aa2d6888ab]
module.vpc.aws_subnet.public[0]: Creation complete after 2s [id=subnet-02de1c9d44e8d0213]
module.vpc.aws_route_table_association.public[1]: Creating...
module.vpc.aws_route_table_association.public[0]: Creating...
module.vpc.aws_nat_gateway.this[1]: Creating...
module.vpc.aws_route.public_internet_gateway[0]: Creating...
module.vpc.aws_nat_gateway.this[0]: Creating...
module.vpc.aws_subnet.private[1]: Creation complete after 2s [id=subnet-06fbb9ac5b0617fd5]
module.vpc.aws_route_table_association.private[1]: Creating...
module.vpc.aws_route_table_association.private[0]: Creating...
module.vpc.aws_route_table_association.public[1]: Creation complete after 0s [id=rtbassoc-08352ee1ac6ea7587]
module.vpc.aws_route_table_association.public[0]: Creation complete after 0s [id=rtbassoc-0eab4b46148e549bf]
module.vpc.aws_route_table_association.private[1]: Creation complete after 0s [id=rtbassoc-08c39dbb86a44cb73]
module.vpc.aws_route_table_association.private[0]: Creation complete after 0s [id=rtbassoc-0ac49d7ede86b07d9]
module.app_security_group.module.sg.aws_security_group.this_name_prefix[0]: Creation complete after 3s [id=sg-01f4bfa640701812e]
module.app_security_group.module.sg.aws_security_group_rule.ingress_with_self[0]: Creating...
module.app_security_group.module.sg.aws_security_group_rule.ingress_rules[0]: Creating...
module.app_security_group.module.sg.aws_security_group_rule.ingress_rules[3]: Creating...
module.app_security_group.module.sg.aws_security_group_rule.ingress_rules[1]: Creating...
module.app_security_group.module.sg.aws_security_group_rule.ingress_rules[2]: Creating...
module.app_security_group.module.sg.aws_security_group_rule.egress_rules[0]: Creating...
module.vpc.aws_route.public_internet_gateway[0]: Creation complete after 1s [id=r-rtb-0490a1cb8968830c11080289494]
module.lb_security_group.module.sg.aws_security_group.this_name_prefix[0]: Creation complete after 3s [id=sg-0ef7204380204aa99]
module.lb_security_group.module.sg.aws_security_group_rule.ingress_rules[3]: Creating...
module.lb_security_group.module.sg.aws_security_group_rule.ingress_rules[0]: Creating...
module.app_security_group.module.sg.aws_security_group_rule.ingress_rules[2]: Creation complete after 1s [id=sgrule-2997949454]
module.lb_security_group.module.sg.aws_security_group_rule.ingress_rules[2]: Creating...
module.lb_security_group.module.sg.aws_security_group_rule.ingress_rules[0]: Creation complete after 1s [id=sgrule-3237002490]
module.lb_security_group.module.sg.aws_security_group_rule.ingress_with_self[0]: Creating...
module.app_security_group.module.sg.aws_security_group_rule.ingress_with_self[0]: Creation complete after 2s [id=sgrule-978834785]
module.lb_security_group.module.sg.aws_security_group_rule.ingress_rules[3]: Creation complete after 2s [id=sgrule-3332535298]
module.lb_security_group.module.sg.aws_security_group_rule.ingress_rules[1]: Creating...
module.lb_security_group.module.sg.aws_security_group_rule.egress_rules[0]: Creating...
module.app_security_group.module.sg.aws_security_group_rule.ingress_rules[1]: Creation complete after 3s [id=sgrule-3671245648]
module.lb_security_group.module.sg.aws_security_group_rule.ingress_rules[2]: Creation complete after 2s [id=sgrule-2326221970]
module.elb_http.module.elb.aws_elb.this[0]: Creating...
module.lb_security_group.module.sg.aws_security_group_rule.ingress_with_self[0]: Creation complete after 3s [id=sgrule-2939679174]
module.app_security_group.module.sg.aws_security_group_rule.ingress_rules[3]: Creation complete after 4s [id=sgrule-1687026475]
module.app_security_group.module.sg.aws_security_group_rule.egress_rules[0]: Creation complete after 5s [id=sgrule-165734166]
module.lb_security_group.module.sg.aws_security_group_rule.ingress_rules[1]: Creation complete after 4s [id=sgrule-2138750510]
module.lb_security_group.module.sg.aws_security_group_rule.egress_rules[0]: Creation complete after 5s [id=sgrule-3642227934]
module.app_security_group.module.sg.aws_security_group_rule.ingress_rules[0]: Creation complete after 7s [id=sgrule-686683333]
module.vpc.aws_nat_gateway.this[1]: Still creating... [10s elapsed]
module.vpc.aws_nat_gateway.this[0]: Still creating... [10s elapsed]
module.elb_http.module.elb.aws_elb.this[0]: Creation complete after 6s [id=lb-BfA-project-alpha-dev]
module.vpc.aws_nat_gateway.this[0]: Still creating... [20s elapsed]
module.vpc.aws_nat_gateway.this[1]: Still creating... [20s elapsed]
module.vpc.aws_nat_gateway.this[1]: Still creating... [30s elapsed]
module.vpc.aws_nat_gateway.this[0]: Still creating... [30s elapsed]
module.vpc.aws_nat_gateway.this[1]: Still creating... [40s elapsed]
module.vpc.aws_nat_gateway.this[0]: Still creating... [40s elapsed]
module.vpc.aws_nat_gateway.this[0]: Still creating... [50s elapsed]
module.vpc.aws_nat_gateway.this[1]: Still creating... [50s elapsed]
module.vpc.aws_nat_gateway.this[0]: Still creating... [1m0s elapsed]
module.vpc.aws_nat_gateway.this[1]: Still creating... [1m0s elapsed]
module.vpc.aws_nat_gateway.this[1]: Still creating... [1m10s elapsed]
module.vpc.aws_nat_gateway.this[0]: Still creating... [1m10s elapsed]
module.vpc.aws_nat_gateway.this[0]: Still creating... [1m20s elapsed]
module.vpc.aws_nat_gateway.this[1]: Still creating... [1m20s elapsed]
module.vpc.aws_nat_gateway.this[0]: Still creating... [1m30s elapsed]
module.vpc.aws_nat_gateway.this[1]: Still creating... [1m30s elapsed]
module.vpc.aws_nat_gateway.this[1]: Still creating... [1m40s elapsed]
module.vpc.aws_nat_gateway.this[0]: Still creating... [1m40s elapsed]
module.vpc.aws_nat_gateway.this[1]: Still creating... [1m50s elapsed]
module.vpc.aws_nat_gateway.this[0]: Still creating... [1m50s elapsed]
module.vpc.aws_nat_gateway.this[0]: Still creating... [2m0s elapsed]
module.vpc.aws_nat_gateway.this[1]: Still creating... [2m0s elapsed]
module.vpc.aws_nat_gateway.this[0]: Creation complete after 2m9s [id=nat-003102be1948e2424]
module.vpc.aws_nat_gateway.this[1]: Still creating... [2m10s elapsed]
module.vpc.aws_nat_gateway.this[1]: Creation complete after 2m19s [id=nat-051a5b1d6f3d1c45e]
module.vpc.aws_route.private_nat_gateway[0]: Creating...
module.vpc.aws_route.private_nat_gateway[1]: Creating...
module.vpc.aws_route.private_nat_gateway[0]: Creation complete after 2s [id=r-rtb-0796930b3c16403811080289494]
module.vpc.aws_route.private_nat_gateway[1]: Creation complete after 2s [id=r-rtb-0779b38e7c6bff2b81080289494]
module.ec2_instances.data.aws_ami.amazon_linux: Reading...
module.ec2_instances.data.aws_ami.amazon_linux: Read complete after 0s [id=ami-0620766f9d10d6c9e]
module.ec2_instances.aws_instance.app[1]: Creating...
module.ec2_instances.aws_instance.app[0]: Creating...
module.ec2_instances.aws_instance.app[1]: Still creating... [10s elapsed]
module.ec2_instances.aws_instance.app[0]: Still creating... [10s elapsed]
module.ec2_instances.aws_instance.app[0]: Still creating... [20s elapsed]
module.ec2_instances.aws_instance.app[1]: Still creating... [20s elapsed]
module.ec2_instances.aws_instance.app[1]: Still creating... [30s elapsed]
module.ec2_instances.aws_instance.app[0]: Still creating... [30s elapsed]
module.ec2_instances.aws_instance.app[1]: Creation complete after 35s [id=i-0f2f7121a1fdb72ac]
module.ec2_instances.aws_instance.app[0]: Creation complete after 35s [id=i-0cd0a64003a65759f]
module.elb_http.module.elb_attachment.aws_elb_attachment.this[1]: Creating...
module.elb_http.module.elb_attachment.aws_elb_attachment.this[0]: Creating...
module.elb_http.module.elb_attachment.aws_elb_attachment.this[1]: Creation complete after 0s [id=lb-BfA-project-alpha-dev-20221010194911256200000003]
module.elb_http.module.elb_attachment.aws_elb_attachment.this[0]: Creation complete after 0s [id=lb-BfA-project-alpha-dev-20221010194911261400000004]

Apply complete! Resources: 40 added, 0 changed, 0 destroyed.

Outputs:

public_dns_name = "lb-BfA-project-alpha-dev-2032997884.us-west-2.elb.amazonaws.com"
```
</details>